### PR TITLE
fix: CQDG-292 remove unused hpo mondo and icd fields from study

### DIFF
--- a/config/output/config/prd-cqdg.conf
+++ b/config/output/config/prd-cqdg.conf
@@ -818,7 +818,7 @@ datalake {
         {
             filesystem=S3
             id=storage
-            path="s3a://cqdg-prod-app-clinical-data-service"
+            path="s3a://cqdg-prod-app-datalake"
         },
         {
             filesystem=S3

--- a/config/output/config/qa-cqdg.conf
+++ b/config/output/config/qa-cqdg.conf
@@ -818,7 +818,7 @@ datalake {
         {
             filesystem=S3
             id=storage
-            path="s3a://cqdg-qa-app-clinical-data-service"
+            path="s3a://cqdg-qa-app-datalake"
         },
         {
             filesystem=S3

--- a/config/src/main/scala/bio/ferlab/fhir/etl/config/ConfigurationGenerator.scala
+++ b/config/src/main/scala/bio/ferlab/fhir/etl/config/ConfigurationGenerator.scala
@@ -121,7 +121,14 @@ object ConfigurationGenerator extends App {
     )
   )).toList
 
-  val cqdgConf = Map("fhir" -> "http://localhost:8080", "qaDbName" -> "cqdg_portal_qa", "prdDbName" -> "cqdg_portal_prd", "localDbName" -> "normalized", "bucketNamePrefix" -> "cqdg-qa-app-clinical-data-service", "bucketNamePrefixPrd" -> "cqdg-prod-app-clinical-data-service")
+  val cqdgConf = Map(
+    "fhir" -> "http://localhost:8080",
+    "qaDbName" -> "cqdg_portal_qa",
+    "prdDbName" -> "cqdg_portal_prd",
+    "localDbName" -> "normalized",
+    "bucketNamePrefix" -> "cqdg-qa-app-datalake",
+    "bucketNamePrefixPrd" -> "cqdg-prod-app-datalake"
+  )
   val conf = Map("cqdg" -> cqdgConf)
 
   val spark_conf = Map(

--- a/prepare-index/src/test/scala/StudyCentricSpec.scala
+++ b/prepare-index/src/test/scala/StudyCentricSpec.scala
@@ -59,9 +59,6 @@ class StudyCentricSpec extends AnyFlatSpec with Matchers with WithSparkSession {
       "normalized_phenotype" -> Seq(phenotype1, phenotype2, phenotype3).toDF(),
       "normalized_biospecimen" -> Seq(biospecimen1, biospecimen2).toDF(),
       "normalized_sample_registration" -> Seq(sample1, sample2, sample3, sample4).toDF(),
-      "hpo_terms" -> read(getClass.getResource("/hpo_terms.json").toString, "Json", Map(), None, None),
-      "mondo_terms" -> read(getClass.getResource("/mondo_terms.json").toString, "Json", Map(), None, None),
-      "icd_terms" -> read(getClass.getResource("/icd_terms.json").toString, "Json", Map(), None, None),
       "duo_terms" -> read(getClass.getResource("/duo_terms.csv").toString, "csv", Map("header" -> "true"), None, None),
     )
 
@@ -73,12 +70,6 @@ class StudyCentricSpec extends AnyFlatSpec with Matchers with WithSparkSession {
     val study_centric = output("es_index_study_centric")
 
     val studyCentricOutput = STUDY_CENTRIC(
-      `mondo_terms` = Seq("rheumatoid arthritis (MONDO:0008383)", "atopic eczema (MONDO:0004980)"),
-      `icd_terms` = Seq(
-        "Rheumatoid arthritis, unspecified (M06.9)",
-        "Atopic dermatitis, unspecified (L20.9)",
-        "Tinnitus, unspecified ear (H93.19)",
-      ),
       `participant_count` = 2, // PRT0000001, PRT0000002
       `data_types` = Seq(("SSUP","1"), ("SNV","1"), ("GCNV","2"), ("ALIR","1"), ("GSV","1")),
       `sample_count` = 4,

--- a/prepare-index/src/test/scala/model/STUDY_CENTRIC.scala
+++ b/prepare-index/src/test/scala/model/STUDY_CENTRIC.scala
@@ -39,9 +39,6 @@ case class STUDY_CENTRIC (
                            `family_count`: Int = 1,
                            `sample_count`: Int = 1,
                            `experimental_strategies`: Seq[String] = Seq("WXS"),
-                           `hpo_terms`: Seq[String] = Seq("Hypercholesterolemia (HP:0003124)", "Hypertension (HP:0000822)"),
-                           `mondo_terms`: Seq[String] = Seq("atopic eczema (MONDO:0004980)"),
-                           `icd_terms`: Seq[String] = Seq("Tinnitus, unspecified ear (H93.19)", "Atopic dermatitis, unspecified (L20.9)", "Hyperchylomicronemia (E78.3)"),
                            `family_data`: Boolean = true,
                            `data_access_codes`: ACCESS_REQUIREMENTS = ACCESS_REQUIREMENTS(),
                          )


### PR DESCRIPTION
Remove the list of HPO, Mondo and ICD terms form the `study_centric` index. It is not mor required.