### PR TITLE
fix: CQDG-347 fix dataset count, explude CRAI files, and parm rename …

### DIFF
--- a/index-task/src/main/resources/templates/template_study_centric.json
+++ b/index-task/src/main/resources/templates/template_study_centric.json
@@ -82,10 +82,10 @@
             "description": {
               "type": "keyword"
             },
-            "data_type": {
+            "data_types": {
               "type": "keyword"
             },
-            "experimental_strategy": {
+            "experimental_strategies": {
               "type": "keyword"
             },
             "participant_count": {

--- a/prepare-index/src/test/scala/FileCentricSpec.scala
+++ b/prepare-index/src/test/scala/FileCentricSpec.scala
@@ -16,6 +16,7 @@ class FileCentricSpec extends AnyFlatSpec with Matchers with WithSparkSession {
     val data: Map[String, DataFrame] = Map(
       "normalized_document_reference" -> Seq(
         DOCUMENTREFERENCE(`fhir_id` = "11", `participant_id` = "P1", `biospecimen_reference` = "B1", `files` = Seq(FILE())),
+        DOCUMENTREFERENCE(`fhir_id` = "12", `participant_id` = "P1", `biospecimen_reference` = "B2", `files` = Seq(FILE(`file_name` = "file.1", `file_format` = "CRAM"), FILE(`file_name` = "file.2", `file_format` = "CRAI"))),
       ).toDF(),
       "normalized_biospecimen" -> Seq(
         BIOSPECIMEN_INPUT(`fhir_id` = "B1", `subject` = "P1"),
@@ -42,6 +43,8 @@ class FileCentricSpec extends AnyFlatSpec with Matchers with WithSparkSession {
     output.keys should contain("es_index_file_centric")
 
     val file_centric = output("es_index_file_centric").as[FILE_CENTRIC].collect()
+
+    output("es_index_file_centric").count() shouldEqual 2 //CRAI files are excluded
 
     file_centric.find(_.file_id == "11") shouldBe Some(
         FILE_CENTRIC(

--- a/prepare-index/src/test/scala/StudyCentricSpec.scala
+++ b/prepare-index/src/test/scala/StudyCentricSpec.scala
@@ -76,8 +76,9 @@ class StudyCentricSpec extends AnyFlatSpec with Matchers with WithSparkSession {
       `sample_count` = 4,
       `data_categories` = Seq(("Genomics","2")),
       `datasets` = Seq(
-        DATASET(`name` = "dataset1", `data_type` = Seq("SNV", "GSV", "ALIR", "SSUP", "GCNV"), `experimental_strategy` = Seq("WXS"), `participant_count` = 1, `file_count` = 6),
-        DATASET(`name` = "dataset2", `description` = Some("desc"), `data_type` = Seq("GCNV"), `experimental_strategy` = Nil, `participant_count` = 1, `file_count` = 1)
+        // Dataset file_count should be 5 as CRAI files should be excluded
+        DATASET(`name` = "dataset1", `data_types` = Seq("SNV", "GSV", "ALIR", "SSUP", "GCNV"), `experimental_strategies` = Seq("WXS"), `participant_count` = 1, `file_count` = 5),
+        DATASET(`name` = "dataset2", `description` = Some("desc"), `data_types` = Seq("GCNV"), `experimental_strategies` = Nil, `participant_count` = 1, `file_count` = 1)
       )
     )
 

--- a/prepare-index/src/test/scala/model/STUDY_CENTRIC.scala
+++ b/prepare-index/src/test/scala/model/STUDY_CENTRIC.scala
@@ -67,8 +67,8 @@ case class ACCESS_REQUIREMENTS(
 case class DATASET(
                     `name`: String = "name 1",
                     `description`: Option[String] = None,
-                    `data_type`: Seq[String] = Seq("SNV"),
-                    `experimental_strategy`: Seq[String] = Seq("WGS"),
+                    `data_types`: Seq[String] = Seq("SNV"),
+                    `experimental_strategies`: Seq[String] = Seq("WGS"),
                     `participant_count`: Int = 100,
                     `file_count`: Int = 100,
                   )


### PR DESCRIPTION
…for datasets

This PR removes the CRAI files from the dataset count. They are excluded form the portal (not shown), should not be counted.

2 Datasets parameters are renamed: `experimental_strategy` -> `experimental_strategies`, `data_type` -> `data_types`