### PR TITLE
fix: CQDG-1397 Fixed bug with restricted studies

### DIFF
--- a/prepare-index/src/main/scala/bio/ferlab/fhir/etl/PrepareIndex.scala
+++ b/prepare-index/src/main/scala/bio/ferlab/fhir/etl/PrepareIndex.scala
@@ -33,7 +33,7 @@ object PrepareIndex extends SparkApp {
       .map(r => r.getString(0))
       .toList
 
-  new SimpleParticipant(filteredStudies).run()
+  if (filteredStudies.nonEmpty) new SimpleParticipant(filteredStudies).run()
 
   jobName match {
     case "study_centric"       =>


### PR DESCRIPTION
## 📌 Context

This PR fixes a bug in the `prepare-index` task, where restricted studies were causing filtering on an empty list.

## 🔗 Related Issues

- [CQDG-1397](https://ferlab-crsj.atlassian.net/browse/CQDG-1397?atlOrigin=eyJpIjoiYTE3NWVmNTJmYTFjNDhiMmE1ZTNhMmViZGQ0N2MwZjUiLCJwIjoiaiJ9)

[CQDG-1397]: https://ferlab-crsj.atlassian.net/browse/CQDG-1397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ