### PR TITLE
feat: CQDG-1422 Propagate stable_file_id to the file-centric Elasticsearch index

### DIFF
--- a/prepare-index/src/test/scala/model/DOCUMENTREFERENCE.scala
+++ b/prepare-index/src/test/scala/model/DOCUMENTREFERENCE.scala
@@ -18,5 +18,6 @@ case class FILE(
     `file_format`: String = "TGZ",
     `file_size`: Long = 56,
     `ferload_url`: String = "http://flerloadurl/outputPrefix/bc3aaa2a-63e4-4201-aec9-6b7b41a1e64a",
-    `file_hash`: String = "d41d8cd98f00b204e9800998ecf8427e"
+    `file_hash`: String = "d41d8cd98f00b204e9800998ecf8427e",
+    `stable_file_id`: String = "FH0000101"
 )

--- a/prepare-index/src/test/scala/model/FILE_CENTRIC.scala
+++ b/prepare-index/src/test/scala/model/FILE_CENTRIC.scala
@@ -13,6 +13,7 @@ case class FILE_CENTRIC(
     file_format: String = "VCF",
     file_size: Double = 1118934.0,
     file_hash: String = "d41d8cd98f00b204e9800998ecf8427e",
+    stable_file_id: String = "FH0000101",
     ferload_url: String =
       "https://ferload.qa.cqdg.ferlab.bio/e24d78edeff9e033dac8445d32835c46c480d8a4|NWQ3MDA3NGY2YzAwMmFiOWE1YzdiZDVmNTFlZmU5YTcgIE5TLjE4ODUuSURUX2k3Xzg3LS0tSURUX2k1Xzg3LjExMTM3MjMwLnN2LnZjZi5neg==",
     `biospecimens`: Set[BIOSPECIMEN] = Set.empty,


### PR DESCRIPTION
## 📌 Context

The new stable path-based file identifier (`FH-------`, derived from `SHA1({bucket}/{path})`) must be present in the file-centric Elasticsearch index so it is queryable and displayable from the portal. This is the **prepare-index** half of the work; the **import-task** part (extracting `stable_file_id` from the FHIR `DocumentReference` extension into the normalized document reference) was already merged in CQDG-1421 (#127).

## 📝 Changes

- **`index-task/.../templates/template_file_centric.json`**: declared `stable_file_id` as a `keyword` field (alongside `file_hash`) so it is explicitly mapped and queryable instead of relying on ES dynamic mapping.
- **`prepare-index/.../model/DOCUMENTREFERENCE.scala`**: added `stable_file_id` to the `FILE` test input model.
- **`prepare-index/.../model/FILE_CENTRIC.scala`**: added `stable_file_id` to the expected-output model so `FileCentricSpec` verifies the field reaches the index.


## 🧪 Tests

- `FileCentricSpec`: passes; confirms `stable_file_id` propagates to each file-centric document with an `FH...` value.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->

- [CQDG-1422](https://ferlab-crsj.atlassian.net/browse/CQDG-1422)

<!-- End JIRA Issues -->

[CQDG-1422]: https://ferlab-crsj.atlassian.net/browse/CQDG-1422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ