### PR TITLE
fix: CQDG-1476 fixed missing stable file id in file centric template

### DIFF
--- a/index-task/src/main/resources/templates/template_file_centric.json
+++ b/index-task/src/main/resources/templates/template_file_centric.json
@@ -1,7 +1,5 @@
 {
-  "index_patterns": [
-    "file_centric*"
-  ],
+  "index_patterns": ["file_centric*"],
   "priority": 1,
   "template": {
     "settings": {
@@ -81,6 +79,10 @@
         },
         "file_hash": {
           "type": "keyword"
+        },
+        "stable_file_id": {
+          "type": "keyword",
+          "normalizer": "custom_normalizer"
         },
         "biospecimens": {
           "type": "nested",


### PR DESCRIPTION
## 📌 Context

`stable_file_id` is missing for file centric elastic template, making it impossible to search by `FH------`.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [CQDG-1476](https://ferlab-crsj.atlassian.net/browse/CQDG-1476)
<!-- End JIRA Issues -->

[CQDG-1476]: https://ferlab-crsj.atlassian.net/browse/CQDG-1476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ