### PR TITLE
fix: CQDG-1498 Added stable file id to biospecimen and participant template

### DIFF
--- a/index-task/src/main/resources/templates/template_biospecimen_centric.json
+++ b/index-task/src/main/resources/templates/template_biospecimen_centric.json
@@ -455,6 +455,10 @@
             "file_id": {
               "type": "keyword"
             },
+            "stable_file_id": {
+              "type": "keyword",
+              "normalizer": "custom_normalizer"
+            },
             "file_2_id": {
               "type": "keyword"
             },

--- a/index-task/src/main/resources/templates/template_participant_centric.json
+++ b/index-task/src/main/resources/templates/template_participant_centric.json
@@ -460,6 +460,10 @@
             "file_id": {
               "type": "keyword"
             },
+            "stable_file_id": {
+              "type": "keyword",
+              "normalizer": "custom_normalizer"
+            },
             "file_2_id": {
               "type": "keyword"
             },

--- a/prepare-index/src/test/scala/model/FILE_INPUT.scala
+++ b/prepare-index/src/test/scala/model/FILE_INPUT.scala
@@ -26,6 +26,7 @@ case class FILE_WITH_SEQ_EXPERIMENT(
     `file_hash`: String = "d41d8cd98f00b204e9800998ecf8427e",
     `ferload_url`: String = "https://ferload.qa.cqdg.ferlab.bio/7b21b84d6034cff9ee187c242fa21ae5be2164ef",
     `file_id`: String = "FIL0081238",
+    `stable_file_id`: String = "FH0000101",
     `file_2_id`: String = "FIL0081238",
     `biospecimen_reference`: Seq[String] = Seq("SAM0234037"),
     `data_category`: String = "Genomics",

--- a/prepare-index/src/test/scala/model/FILE_WITH_BIOSPECIMEN.scala
+++ b/prepare-index/src/test/scala/model/FILE_WITH_BIOSPECIMEN.scala
@@ -2,6 +2,7 @@ package model
 
 case class FILE_WITH_BIOSPECIMEN(
     `file_id`: Option[String] = Some("FIL0086557"),
+    `stable_file_id`: Option[String] = Some("FH0000101"),
     `file_2_id`: Option[String] = Some("FIL0086557"),
     `biospecimen_reference`: Seq[String] = Seq("SAM0247817"),
     `data_type`: Option[String] = Some("Structural Variations (SVs)"),


### PR DESCRIPTION
## 📌 Context

In the Data Explorer, filtering by **File ID** (an `FH…` value) returned the correct result count on the **Data Files** tab but **0** on the **Participants** and **Biospecimens** tabs. This PR filters by the correct ID value for **Participants** and **Biospecimens** too.

## 📝 Changes

- Added `stable_file_id` (`keyword` + `custom_normalizer`, mirroring `file_centric`) to the nested `files` object in `template_participant_centric.json` and `template_biospecimen_centric.json`.
- Added `stable_file_id` to the `FILE_WITH_BIOSPECIMEN` and `FILE_WITH_SEQ_EXPERIMENT` test models so `ParticipantCentricSpec` / `BiospecimenCentricSpec` now assert the field is propagated into the nested files struct (regression guard).

## 🧪 Tests

- Updated `ParticipantCentricSpec` and `BiospecimenCentricSpec`, they now decode the nested `stable_file_id` and assert its value (`FH0000101`). The `.as[...]` decode would fail if the field were absent from the output, so these specs prove the field is actually produced.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [CQDG-1498](https://ferlab-crsj.atlassian.net/browse/CQDG-1498)
<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- The fix is inert until the two indices are reindexed. No portal-ui change is required.

[CQDG-1498]: https://ferlab-crsj.atlassian.net/browse/CQDG-1498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ