### PR TITLE
fix: CQDG-1524 Added file count to data category and data type

### DIFF
--- a/index-task/src/main/resources/templates/template_study_centric.json
+++ b/index-task/src/main/resources/templates/template_study_centric.json
@@ -121,6 +121,9 @@
             },
             "participant_count": {
               "type": "integer"
+            },
+            "file_count": {
+              "type": "integer"
             }
           }
         },
@@ -131,6 +134,9 @@
               "type": "keyword"
             },
             "participant_count": {
+              "type": "integer"
+            },
+            "file_count": {
               "type": "integer"
             }
           }

--- a/prepare-index/src/main/scala/bio/ferlab/fhir/etl/common/Utils.scala
+++ b/prepare-index/src/main/scala/bio/ferlab/fhir/etl/common/Utils.scala
@@ -27,7 +27,7 @@ object Utils {
     }
 
     /** assume df is study, will add data Categories already on the study to the data category found on the files format
-      * have to be [(data_Category_type, count)]>
+      * have to be [(data_Category_type, participant_count, file_count)]>
       *
       * @param dataCategoryCount
       *   : Data Categories and count based on DocumentReference
@@ -41,7 +41,12 @@ object Utils {
         .filter(!array_contains(col("data_categories_from_files")("data_category"), col("data_categories_exp")))
         .withColumn(
           "data_categories",
-          struct(col("data_categories_exp") as "data_category", lit(null).cast("integer") as "participant_count")
+          // must stay structurally identical to what fieldCount produces, both arrays are concatenated below
+          struct(
+            col("data_categories_exp") as "data_category",
+            lit(null).cast("integer") as "participant_count",
+            lit(null).cast("integer") as "file_count"
+          )
         )
         .groupBy("study_id")
         .agg(collect_set("data_categories") as "data_categories")
@@ -248,14 +253,24 @@ object Utils {
         .drop("subject")
     }
 
+    /** Counts participants and files per value of `field`. A file is identified the same way as in the study
+      * file_count, so that the file counts of all the values of `field` add up to the file_count of the study.
+      */
     def fieldCount(field: String, countField: String): DataFrame = df
       .withColumn("files_exp", explode(col("files")))
       .na
       .drop(Seq(s"files_exp.$field"))
       .groupBy("study_id", s"files_exp.$field")
-      .agg(size(collect_set(col("subject"))) as "participant_count")
+      .agg(
+        size(collect_set(col("subject"))) as "participant_count",
+        size(
+          collect_set(
+            struct(col("files_exp.file_name"), col("files_exp.file_format"), col("files_exp.file_id"))
+          )
+        ) as "file_count"
+      )
       .groupBy("study_id")
-      .agg(collect_list(struct(col(field), col("participant_count"))) as countField)
+      .agg(collect_list(struct(col(field), col("participant_count"), col("file_count"))) as countField)
 
     def addFilesWithBiospecimen(
         filesDf: DataFrame,

--- a/prepare-index/src/test/scala/StudyCentricSpec.scala
+++ b/prepare-index/src/test/scala/StudyCentricSpec.scala
@@ -193,8 +193,15 @@ class StudyCentricSpec extends AnyFlatSpec with Matchers with WithSparkSession {
 
     val studyCentricOutput = STUDY_CENTRIC(
       `participant_count` = 2, // PRT0000001, PRT0000002
-      `data_types` =
-        Seq(("SSUP", "1"), ("Annotated-SNV", "1"), ("SNV", "1"), ("GCNV", "2"), ("ALIR", "1"), ("GSV", "1")),
+      // GCNV is the only data type with 2 files (file3.vcf and file6.vcf), all the file counts add up to file_count
+      `data_types` = Seq(
+        ("SSUP", "1", "1"),
+        ("Annotated-SNV", "1", "1"),
+        ("SNV", "1", "1"),
+        ("GCNV", "2", "2"),
+        ("ALIR", "1", "1"),
+        ("GSV", "1", "1")
+      ),
       `sample_count` = 4,
       `file_count` = 7,
       `datasets` = Seq(

--- a/prepare-index/src/test/scala/UtilsSpec.scala
+++ b/prepare-index/src/test/scala/UtilsSpec.scala
@@ -218,7 +218,8 @@ class UtilsSpec extends AnyFlatSpec with Matchers with WithSparkSession {
         ArrayType(
           StructType(
             StructField("data_category", StringType, true) ::
-              StructField("participant_count", IntegerType, false) :: Nil
+              StructField("participant_count", IntegerType, false) ::
+              StructField("file_count", IntegerType, false) :: Nil
           )
         ),
         true
@@ -235,21 +236,21 @@ class UtilsSpec extends AnyFlatSpec with Matchers with WithSparkSession {
       )
     ).toDF()
 
-    val data1 = Seq(Row("study1", Seq(Row("data_category1", 12), Row("data_category2", 2))))
+    val data1 = Seq(Row("study1", Seq(Row("data_category1", 12, 30), Row("data_category2", 2, 5))))
 
     val dataCategoriesFromFiles1 = spark.createDataFrame(spark.sparkContext.parallelize(data1), schema)
 
     val output1 = study1Df
       .combineDataCategoryFromFilesAndStudy(dataCategoriesFromFiles1)
       .select("data_categories")
-      .as[Seq[(String, Option[Int])]]
+      .as[Seq[(String, Option[Int], Option[Int])]]
       .collect()
       .head
 
     output1 should contain theSameElementsAs Seq(
-      ("data_category1", Some(12)),
-      ("data_category2", Some(2)),
-      ("data_category3", None)
+      ("data_category1", Some(12), Some(30)),
+      ("data_category2", Some(2), Some(5)),
+      ("data_category3", None, None)
     )
 
     // No extra Data categories from files
@@ -257,17 +258,17 @@ class UtilsSpec extends AnyFlatSpec with Matchers with WithSparkSession {
       RESEARCHSTUDY(`study_id` = "study1", `data_categories` = Seq("data_category2"))
     ).toDF()
 
-    val data2 = Seq(Row("study1", Seq(Row("data_category2", 12))))
+    val data2 = Seq(Row("study1", Seq(Row("data_category2", 12, 30))))
 
     val dataCategoriesFromFiles2 = spark.createDataFrame(spark.sparkContext.parallelize(data2), schema)
 
     val output2 = study2Df
       .combineDataCategoryFromFilesAndStudy(dataCategoriesFromFiles2)
       .select("data_categories")
-      .as[Seq[(String, Option[Int])]]
+      .as[Seq[(String, Option[Int], Option[Int])]]
       .collect()
       .head
 
-    output2 should contain theSameElementsAs Seq(("data_category2", Some(12)))
+    output2 should contain theSameElementsAs Seq(("data_category2", Some(12), Some(30)))
   }
 }

--- a/prepare-index/src/test/scala/model/STUDY_CENTRIC.scala
+++ b/prepare-index/src/test/scala/model/STUDY_CENTRIC.scala
@@ -25,8 +25,10 @@ case class STUDY_CENTRIC(
     `restricted_number_participants`: String = "2",
     `restricted_number_biospecimens`: String = "3",
     `restricted_number_files`: String = "3",
-    `data_types`: Seq[(String, String)] = Seq(("SSUP", "1"), ("SNV", "1"), ("GCNV", "1"), ("ALIR", "1"), ("GSV", "1")),
-    `data_categories`: Seq[(String, String)] = Seq(("Genomics", "2"), ("Proteomics", null), ("Transcriptomics", null)),
+    `data_types`: Seq[(String, String, String)] =
+      Seq(("SSUP", "1", "1"), ("SNV", "1", "1"), ("GCNV", "1", "1"), ("ALIR", "1", "1"), ("GSV", "1", "1")),
+    `data_categories`: Seq[(String, String, String)] =
+      Seq(("Genomics", "2", "7"), ("Transcriptomics", null, null), ("Proteomics", null, null)),
     `study_designs`: Seq[String] = Seq("case_only", "registry"),
     `data_collection_methods`: Seq[String] = Seq("medical_records", "investigator_assessment"),
     `participant_count`: Int = 1,


### PR DESCRIPTION
## 📌 Context

Data categories and data types in `study_centric` only exposed a `participant_count`. The portal also needs to show how many files belong to each data category / data type, so the counts had to be added to those aggregations.

## 📝 Changes

- `Utils.fieldCount` now also computes a `file_count` per value of the field, using the same file identity as the study-level `file_count` (`file_name`, `file_format`, `file_id`) so the per-value counts add up to the study total.
- `combineDataCategoryFromFilesAndStudy` emits a `null` `file_count` for data categories declared on the study but absent from the files, keeping the struct shape identical to `fieldCount`'s output (the two arrays get concatenated).
- Added `file_count` to `data_types` and `data_categories` in `template_study_centric.json`.

## ☑️ TO-DOs

- [ ] Re-index `study_centric` so the new field is populated

## 🧪 Tests

- Updated `UtilsSpec` (`combineDataCategoryFromFilesAndStudy`) for the 3-field struct, including the `None` `file_count` case for study-only categories.
- Updated `StudyCentricSpec` / `STUDY_CENTRIC` expectations: `GCNV` is the only data type with 2 files, and the per-data-type file counts sum to the study `file_count` (7).

## 🔗 Related Issues

<!-- Begin JIRA Issues -->

- [CQDG-1524](https://ferlab-crsj.atlassian.net/browse/CQDG-1524)

<!-- End JIRA Issues -->

[CQDG-1524]: https://ferlab-crsj.atlassian.net/browse/CQDG-1524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ