### PR TITLE
fix: CQDG-1525 Fixed issue with phenotypes

### DIFF
--- a/prepare-index/src/main/scala/bio/ferlab/fhir/etl/common/OntologyUtils.scala
+++ b/prepare-index/src/main/scala/bio/ferlab/fhir/etl/common/OntologyUtils.scala
@@ -7,6 +7,16 @@ object OntologyUtils {
 
   val displayTerm: (Column, Column) => Column = (id, name) => concat(name, lit(" ("), id, lit(")"))
 
+  private def termsByCode(terms: DataFrame, codeCol: String): DataFrame = {
+    val current = terms.withColumn(codeCol, col("id"))
+    val obsolete = terms.withColumn(codeCol, explode(col("alt_ids")))
+
+    current
+      .unionByName(obsolete.join(current.select(codeCol), Seq(codeCol), "left_anti"))
+      .dropDuplicates(codeCol)
+      .drop("alt_ids")
+  }
+
   def generateTaggedPhenotypes(phenotypes: DataFrame, colName: String): DataFrame = {
     phenotypes
       .filter(col("phenotype_id").isNotNull)
@@ -15,12 +25,13 @@ object OntologyUtils {
         collect_list(
           struct(
             col("fhir_id") as "internal_phenotype_id",
-            lit(true) as "is_tagged",
-            col("is_leaf"),
-            col("parents"),
+            col("name").isNotNull as "is_tagged",
+            coalesce(col("is_leaf"), lit(false)) as "is_leaf",
+            coalesce(col("parents"), array().cast("array<string>")) as "parents",
             col("age_at_event"),
             col("source_text"),
-            displayTerm(col("phenotype_id"), col("name")) as "name"
+            when(col("name").isNotNull, displayTerm(col("phenotype_id"), col("name")))
+              .otherwise(col("phenotype_id")) as "name"
           )
         ) as colName
       )
@@ -70,21 +81,11 @@ object OntologyUtils {
   }
 
   def getTaggedPhenotypes(phenotypesDF: DataFrame, hpoTerms: DataFrame): (DataFrame, DataFrame, DataFrame) = {
-    val hpoExplodedAlt = hpoTerms
-      .withColumn("alt_id", explode(col("alt_ids")))
-
-    val phenotypesWithTermsAlternate = phenotypesDF
-      .withColumn("phenotype_id", col("phenotype_HPO_code")("code"))
-      .join(hpoExplodedAlt, col("phenotype_id") === col("alt_id"), "inner")
-      .drop("phenotype_id", "alt_id")
-      .withColumnRenamed("id", "phenotype_id")
-
-    val phenotypesWithTermsValid = phenotypesDF
-      .withColumn("phenotype_id", col("phenotype_HPO_code")("code"))
-      .join(hpoTerms, col("phenotype_id") === col("id"), "inner")
-      .drop(col("id"))
-
-    val phenotypesWithTerms = phenotypesWithTermsValid.unionByName(phenotypesWithTermsAlternate).drop("alt_ids")
+    val phenotypesWithTerms = phenotypesDF
+      .withColumn("hpo_code", col("phenotype_HPO_code")("code"))
+      .join(termsByCode(hpoTerms, "hpo_code"), Seq("hpo_code"), "left_outer")
+      .withColumn("phenotype_id", coalesce(col("id"), col("hpo_code")))
+      .drop("id", "hpo_code")
 
     val observedPhenotypes = phenotypesWithTerms
       .filter(col("phenotype_observed").equalTo("POS"))

--- a/prepare-index/src/test/scala/OntologyUtilsSpec.scala
+++ b/prepare-index/src/test/scala/OntologyUtilsSpec.scala
@@ -2,6 +2,7 @@ import bio.ferlab.datalake.spark3.loader.GenericLoader.read
 import bio.ferlab.fhir.etl.common.OntologyUtils.{getDiagnosis, getTaggedPhenotypes}
 import model.{
   DIAGNOSIS_INPUT,
+  HPO_TERM,
   PHENOTYPE,
   PHENOTYPE_HPO_CODE,
   PHENOTYPE_TAGGED,
@@ -276,6 +277,60 @@ class OntologyUtilsSpec extends AnyFlatSpec with Matchers with WithSparkSession 
         ),
         PHENOTYPE_TAGGED_WITH_ANCESTORS(`parents` = Nil, `age_at_event` = Seq("Young"), `name` = "A Name (HP:A)")
       )
+  }
+
+  it should "keep a phenotype whose HPO code is absent from the ontology" in {
+    val known = PHENOTYPE(
+      `fhir_id` = "1",
+      `phenotype_source_text` = "Intractable Seizures",
+      `phenotype_HPO_code` = PHENOTYPE_HPO_CODE(`code` = "HP:G"),
+      `cqdg_participant_id` = "1"
+    )
+    val unknown = PHENOTYPE(
+      `fhir_id` = "2",
+      `phenotype_source_text` = "Hand polydactyly",
+      `phenotype_HPO_code` = PHENOTYPE_HPO_CODE(`code` = "HP:NOT_IN_ONTOLOGY"),
+      `cqdg_participant_id` = "1"
+    )
+
+    val (_, withAncestors, t3) = getTaggedPhenotypes(Seq(known, unknown).toDF(), hpo_terms)
+
+    // the unmatched code keeps its source text, falls back to the code for a name, and admits
+    // via is_tagged that it never resolved
+    val taggedPhenotypes = t3.as[(String, Seq[PHENOTYPE_TAGGED_WITH_OBSERVED])].collect().head._2
+
+    taggedPhenotypes.map(p =>
+      (p.`source_text`, p.`name`, p.`is_tagged`)
+    ) should contain theSameElementsAs Seq(
+      ("Intractable Seizures", "G Name (HP:G)", true),
+      ("Hand polydactyly", "HP:NOT_IN_ONTOLOGY", false)
+    )
+
+    // but it stays out of the ancestor tree, which has nothing to hang it from
+    val treeNames =
+      withAncestors.as[(String, Seq[PHENOTYPE_TAGGED_WITH_ANCESTORS])].collect().head._2.map(_.`name`)
+
+    treeNames should contain theSameElementsAs Seq("G Name (HP:G)", "B Name (HP:B)", "A Name (HP:A)")
+  }
+
+  it should "match a code once when it is both a current id and another term's alt_id" in {
+    val terms = Seq(
+      HPO_TERM(`id` = "HP:1", `name` = "One", `alt_ids` = Seq("HP:2")),
+      HPO_TERM(`id` = "HP:2", `name` = "Two")
+    ).toDF()
+
+    val phenotype = PHENOTYPE(
+      `fhir_id` = "1",
+      `phenotype_source_text` = "text",
+      `phenotype_HPO_code` = PHENOTYPE_HPO_CODE(`code` = "HP:2"),
+      `cqdg_participant_id` = "1"
+    )
+
+    val (_, _, t3) = getTaggedPhenotypes(Seq(phenotype).toDF(), terms)
+    val taggedPhenotypes = t3.as[(String, Seq[PHENOTYPE_TAGGED_WITH_OBSERVED])].collect().head._2
+
+    // HP:2 is a current term, so it must not also resolve through HP:1's alt_ids
+    taggedPhenotypes.map(_.`name`) shouldBe Seq("Two (HP:2)")
   }
 
   "getDiagnosis" should "return diagnosis per participant" in {

--- a/prepare-index/src/test/scala/model/PHENOTYPE.scala
+++ b/prepare-index/src/test/scala/model/PHENOTYPE.scala
@@ -23,6 +23,21 @@ case class PHENOTYPE_HPO_CODE(
     `code`: String = "HP:0003124"
 )
 
+case class HPO_ANCESTOR(
+    `id`: String = "HP:0000118",
+    `name`: String = "Phenotypic abnormality",
+    `parents`: Seq[String] = Nil
+)
+
+case class HPO_TERM(
+    `id`: String = "HP:0003124",
+    `name`: String = "Term Name",
+    `parents`: Seq[String] = Nil,
+    `ancestors`: Seq[HPO_ANCESTOR] = Nil,
+    `is_leaf`: Boolean = true,
+    `alt_ids`: Seq[String] = Nil
+)
+
 case class PHENOTYPE_TAGGED(
     `internal_phenotype_id`: String = "1",
     `is_tagged`: Boolean = true,


### PR DESCRIPTION
## 📌 Context

`getTaggedPhenotypes` joined phenotypes to the HPO ontology with an inner join, so any phenotype whose `phenotype_HPO_code` was not in the ontology was silently dropped from the index, the participant lost the phenotype entirely instead of showing it as untagged. The obsolete-code handling also relied on a second join over exploded `alt_ids`, which could yield the same phenotype twice when a code was both a current term id and another term's `alt_id`.

## 📝 Changes

- Replaced the two inner joins (current ids + exploded `alt_ids`) with a single `left_outer` join against a new `termsByCode` helper, so unmatched HPO codes are kept instead of dropped.
- `termsByCode` resolves a code to one term only: current ids win, and an `alt_id` is used only when no current term claims that code (`left_anti` + `dropDuplicates`), removing the duplicate-match case.
- `generateTaggedPhenotypes` now derives `is_tagged` from whether the term resolved, falls back to the raw HPO code for `name`, and defaults `is_leaf` to `false` and `parents` to an empty array for unresolved terms.

## ☑️ TO-DOs

- [ ] Re-run `prepare-index` + re-index so previously dropped phenotypes appear

## 🧪 Tests

- Added `OntologyUtilsSpec` "keep a phenotype whose HPO code is absent from the ontology": the unmatched code keeps its `source_text`, gets the code as its `name`, is `is_tagged = false`, and stays out of the ancestor tree.
- Added `OntologyUtilsSpec` "match a code once when it is both a current id and another term's alt_id": asserts a single match, with the current term winning.
- Added `HPO_TERM` / `HPO_ANCESTOR` test models to build ad-hoc ontologies.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->

- [CQDG-1525](https://ferlab-crsj.atlassian.net/browse/CQDG-1525)

<!-- End JIRA Issues -->

[CQDG-1525]: https://ferlab-crsj.atlassian.net/browse/CQDG-1525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ